### PR TITLE
🪲 [Fix]: Version of Invoke-Pester to v3, was custom branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,8 +56,7 @@ runs:
         Script: ${{ github.action_path }}/scripts/main.ps1
 
     - name: Invoke-Pester
-      # uses: PSModule/Invoke-Pester@v3
-      uses: PSModule/Invoke-Pester@fixCOntainerEval
+      uses: PSModule/Invoke-Pester@v3
       id: test
       env:
         Settings: ${{ fromJson(steps.paths.outputs.result).Settings }}


### PR DESCRIPTION
## Description

This pull request includes a small change to the `action.yml` file. The change reverts the `Invoke-Pester` module to use version `v3` instead of the `fixCOntainerEval` version.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L59-R59): Reverted the `Invoke-Pester` module to use version `v3` instead of `fixCOntainerEval`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
