### PR TITLE
🩹 [Patch]: Align `WorkingDirectory` usage in workflows and update pat…

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -31,9 +31,9 @@ jobs:
         uses: ./
         id: action-test
         with:
-          WorkingDirectory: tests/srcTestRepo
           Path: src
           Settings: SourceCode
+          WorkingDirectory: tests/srcTestRepo
 
       - name: Status
         shell: pwsh
@@ -55,10 +55,10 @@ jobs:
         uses: ./
         id: action-test
         with:
-          WorkingDirectory: tests/srcTestRepo
           Path: src
           Settings: Custom
           SettingsFilePath: tests/Custom.Settings.psd1
+          WorkingDirectory: tests/srcTestRepo
 
       - name: Status
         shell: pwsh
@@ -81,9 +81,9 @@ jobs:
         continue-on-error: true
         id: action-test
         with:
-          WorkingDirectory: tests/srcWithManifestTestRepo
           Path: src
           Settings: SourceCode
+          WorkingDirectory: tests/srcWithManifestTestRepo
 
       - name: Status
         shell: pwsh
@@ -105,9 +105,9 @@ jobs:
         uses: ./
         id: action-test
         with:
-          WorkingDirectory: tests/outputTestRepo
           Path: outputs/modules/PSModuleTest
           Settings: Module
+          WorkingDirectory: tests/outputTestRepo
 
       - name: Status
         shell: pwsh
@@ -229,4 +229,3 @@ jobs:
                 Write-GitHubError 'One or more jobs failed'
                 exit 1
             }
-

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
       - name: Invoke PSScriptAnalyzer
         uses: PSModule/Invoke-ScriptAnalyzer@v2
         with:
-          Path: ${{ github.workspace }}
+          Path: src
           Settings: SourceCode
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
   Path:
     description: The path to the code to test.
     required: false
+    default: '.'
   Settings:
     description: The type of tests to run. Can be either 'Module', 'SourceCode' or 'Custom'.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,6 @@ inputs:
   Path:
     description: The path to the code to test.
     required: false
-    default: '.'
   Settings:
     description: The type of tests to run. Can be either 'Module', 'SourceCode' or 'Custom'.
     required: false

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,13 +1,13 @@
 ﻿# If test type is module, the code we ought to test is in the path/name folder, otherwise it's in the path folder.
 $settings = $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Settings
 $testPath = Resolve-Path -Path "$PSScriptRoot/tests/PSScriptAnalyzer" | Select-Object -ExpandProperty Path
-$codePath = Resolve-Path -Path "./$env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path" | Select-Object -ExpandProperty Path
+$codePath = Resolve-Path -Path $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path | Select-Object -ExpandProperty Path
 $settingsFilePath = switch -Regex ($settings) {
     'Module|SourceCode' {
         "$testPath/$settings.Settings.psd1"
     }
     'Custom' {
-        Resolve-Path -Path "$env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_SettingsFilePath" | Select-Object -ExpandProperty Path
+        Resolve-Path -Path $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_SettingsFilePath | Select-Object -ExpandProperty Path
     }
     default {
         throw "Invalid test type: [$settings]"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -2,7 +2,7 @@
 $settings = $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Settings
 $testPath = Resolve-Path -Path "$PSScriptRoot/tests/PSScriptAnalyzer" | Select-Object -ExpandProperty Path
 $path = [string]::IsNullOrEmpty($env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path) ? '.' : $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path
-$codePath = Resolve-Path -Path $path | Select-Object -ExpandProperty Path | Select-Object -ExpandProperty Path
+$codePath = Resolve-Path -Path $path | Select-Object -ExpandProperty Path
 $settingsFilePath = switch -Regex ($settings) {
     'Module|SourceCode' {
         "$testPath/$settings.Settings.psd1"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,7 +1,7 @@
 ﻿# If test type is module, the code we ought to test is in the path/name folder, otherwise it's in the path folder.
 $settings = $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Settings
 $testPath = Resolve-Path -Path "$PSScriptRoot/tests/PSScriptAnalyzer" | Select-Object -ExpandProperty Path
-$codePath = Resolve-Path -Path $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path | Select-Object -ExpandProperty Path
+$codePath = Resolve-Path -Path "./$env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path" | Select-Object -ExpandProperty Path
 $settingsFilePath = switch -Regex ($settings) {
     'Module|SourceCode' {
         "$testPath/$settings.Settings.psd1"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,7 +1,8 @@
 ﻿# If test type is module, the code we ought to test is in the path/name folder, otherwise it's in the path folder.
 $settings = $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Settings
 $testPath = Resolve-Path -Path "$PSScriptRoot/tests/PSScriptAnalyzer" | Select-Object -ExpandProperty Path
-$codePath = Resolve-Path -Path $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path | Select-Object -ExpandProperty Path
+$path = [string]::IsNullOrEmpty($env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path) ? '.' : $env:PSMODULE_INVOKE_SCRIPTANALYZER_INPUT_Path
+$codePath = Resolve-Path -Path $path | Select-Object -ExpandProperty Path | Select-Object -ExpandProperty Path
 $settingsFilePath = switch -Regex ($settings) {
     'Module|SourceCode' {
         "$testPath/$settings.Settings.psd1"


### PR DESCRIPTION
## Description

This pull request includes changes to ensure consistency in setting the `WorkingDirectory` parameter and improve the handling of paths in the script.

### Changes to workflows

* `.github/workflows/Action-Test.yml`:
  *  Consistently set the `WorkingDirectory` parameter for different job configurations to ensure the correct directory is used in each case.

### Documentation update

* `README.md`:
  * Updated the `Path` parameter in the `Invoke PSScriptAnalyzer` job to use `src` instead of `${{ github.workspace }}` aligning with the change of adding a `WorkingDirectory`.

### Script improvement

* `scripts/main.ps1`:
  * Improved the handling of the `Path` parameter by adding a check for an empty string and defaulting to `'.'` if empty, ensuring the script resolves the correct path.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
