### PR TITLE
🪲 [Fix]: When an issue is found, output script path

### DIFF
--- a/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
+++ b/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
@@ -106,7 +106,8 @@ Describe 'PSScriptAnalyzer' {
                 It "$($rule.CommonName) ($($rule.RuleName))" -Skip:$rule.Skip -ForEach @{ Rule = $rule } {
                     $issues = [Collections.Generic.List[string]]::new()
                     $testResults | Where-Object { $_.RuleName -eq $Rule.RuleName } | ForEach-Object {
-                        $issues.Add(([Environment]::NewLine + " - $relativePath`:L$($_.Line):C$($_.Column)"))
+                        $relativeScriptPath = $_.ScriptPath.Replace($relativePath, '').Trim('\').Trim('/')
+                        $issues.Add(([Environment]::NewLine + " - $relativeScriptPath`:L$($_.Line):C$($_.Column)"))
                     }
                     $issues -join '' | Should -BeNullOrEmpty -Because $rule.Description
                 }

--- a/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
+++ b/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
@@ -92,10 +92,8 @@ Describe 'PSScriptAnalyzer' {
             $testResults = Invoke-ScriptAnalyzer -Path $Path -Settings $SettingsFilePath -Recurse -Verbose
         }
         LogGroup "TestResults [$($testResults.Count)]" {
-            $testResults | ForEach-Object {
-                $_ | Format-List | Out-String -Stream | ForEach-Object {
-                    Write-Verbose $_ -Verbose
-                }
+            $testResults | Select-Object -Property * | Format-List | Out-String -Stream | ForEach-Object {
+                Write-Verbose $_ -Verbose
             }
         }
     }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `PSScriptAnalyzer.Tests.ps1` file. The change modifies the way script paths are handled in test results to improve the readability of issue locations.

* [`scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1`](diffhunk://#diff-506030604c5eac4d6d266aa14f0e8cf3a8121425c1f579406e3a003d5b091ac9L109-R110): Changed the script path handling to use `relativeScriptPath` instead of `relativePath` for better readability in issue locations.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
