### PR TITLE
🩹 [Patch]: Normalize path separators in PSScriptAnalyzer tests

### DIFF
--- a/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
+++ b/scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1
@@ -74,9 +74,9 @@ Describe 'PSScriptAnalyzer' {
         }
         $Path = Resolve-Path -Path $Path | Select-Object -ExpandProperty Path
         $relativePath = if ($Path.StartsWith($PSScriptRoot)) {
-            $Path.Replace($PSScriptRoot, 'Action:').Trim('\').Trim('/')
+            $Path.Replace($PSScriptRoot, 'Action:').Trim('\').Trim('/').Replace('\', '/')
         } elseif ($Path.StartsWith($env:GITHUB_WORKSPACE)) {
-            $Path.Replace($env:GITHUB_WORKSPACE, 'Workspace:').Trim('\').Trim('/')
+            $Path.Replace($env:GITHUB_WORKSPACE, 'Workspace:').Trim('\').Trim('/').Replace('\', '/')
         } else {
             $Path
         }


### PR DESCRIPTION
## Description

This pull request includes a minor change to the `PSScriptAnalyzer.Tests.ps1` file. The change ensures that backslashes are replaced with forward slashes in the paths, improving consistency in path formatting.

* [`scripts/tests/PSScriptAnalyzer/PSScriptAnalyzer.Tests.ps1`](diffhunk://#diff-506030604c5eac4d6d266aa14f0e8cf3a8121425c1f579406e3a003d5b091ac9L77-R79): Modified the path normalization logic to replace backslashes with forward slashes.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
