### PR TITLE
🩹 [Patch]: Add retry on `Install-PSResource`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -138,7 +138,26 @@ jobs:
         uses: PSModule/Github-Script@v1
         with:
           Script: |
-            Install-PSResource -Name Markdown -Repository PSGallery -TrustRepository
+            'Markdown' | ForEach-Object {
+                $name = $_
+                Write-Output "Installing module: $name"
+                $retryCount = 5
+                $retryDelay = 10
+                for ($i = 0; $i -lt $retryCount; $i++) {
+                    try {
+                        Install-PSResource -Name $name -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery
+                        break
+                    } catch {
+                        Write-Warning "Installation of $name failed with error: $_"
+                        if ($i -eq $retryCount - 1) {
+                            throw
+                        }
+                        Write-Warning "Retrying in $retryDelay seconds..."
+                        Start-Sleep -Seconds $retryDelay
+                    }
+                }
+                Import-Module -Name $name
+            }
 
             # Build an array of objects for each job
             $ActionTestSrcSourceCodeExpectedOutcome = 'success'


### PR DESCRIPTION
## Description

This pull request includes changes to the `.github/workflows/Action-Test.yml` file to improve the reliability of module installation by adding retry logic.

Improvements to module installation:

* [`.github/workflows/Action-Test.yml`](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L141-R160): Added a retry mechanism for the `Install-PSResource` command to handle potential installation failures more gracefully. This includes retrying the installation up to 5 times with a 10-second delay between attempts and logging appropriate messages.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
