### PR TITLE
🩹 [Patch]: Remove GITHUB_TOKEN environment variable from Auto-Release

### DIFF
--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -30,7 +30,5 @@ jobs:
 
       - name: Auto-Release
         uses: PSModule/Auto-Release@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
         with:
           IncrementalPrerelease: false


### PR DESCRIPTION
## Description

This pull request includes a small change to the `.github/workflows/Auto-Release.yml` file. The change removes the `env` section that was used for GitHub CLI authentication. 

Changes to `.github/workflows/Auto-Release.yml`:

* Removed the `env` section that contained the `GITHUB_TOKEN` used for GitHub CLI authentication. This is now included in the Auto-Release action.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
