### PR TITLE
🌟 [Major: Bump `Invoke-Pester` to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,17 +41,12 @@ inputs:
       Output generated reports in JSON format in addition to the configured format through Pester.
     required: false
     default: 'true'
-  StepSummary_Enabled:
-    description: |
-      Controls if a GitHub step summary should be shown.
-    required: false
-    default: 'true'
   StepSummary_ShowTestOverview:
     description: |
       Controls whether to show the test overview table in the GitHub step summary.
     required: false
-    default: 'true'
-  StepSummary_ShowTests:
+    default: 'false'
+  StepSummary_Mode:
     description: |
       Controls which tests to show in the GitHub step summary. Allows "Full", "Failed", or "None".
     required: false
@@ -267,7 +262,7 @@ runs:
         Script: ${{ github.action_path }}/scripts/main.ps1
 
     - name: Invoke-Pester
-      uses: PSModule/Invoke-Pester@v3
+      uses: PSModule/Invoke-Pester@v4
       id: test
       env:
         Settings: ${{ fromJson(steps.paths.outputs.result).Settings }}
@@ -282,9 +277,8 @@ runs:
         Path: ${{ github.action_path }}/scripts/tests/PSScriptAnalyzer
         Run_Path: ${{ fromJson(steps.paths.outputs.result).CodePath }}
         ReportAsJson: ${{ inputs.ReportAsJson }}
-        StepSummary_Enabled: ${{ inputs.StepSummary_Enabled }}
         StepSummary_ShowTestOverview: ${{ inputs.StepSummary_ShowTestOverview }}
-        StepSummary_ShowTests: ${{ inputs.StepSummary_ShowTests }}
+        StepSummary_Mode: ${{ inputs.StepSummary_Mode }}
         StepSummary_ShowConfiguration: ${{ inputs.StepSummary_ShowConfiguration }}
         Run_ExcludePath: ${{ inputs.Run_ExcludePath }}
         Run_Exit: ${{ inputs.Run_Exit }}


### PR DESCRIPTION
## Description

This pull request includes updates to the `action.yml` file, bumping the version of the Ìnvoke-Pester` action and adjusting inputs to the updated version.

### Step Summary Configuration Changes:
* 🌟 Removed the `StepSummary_Enabled` input to simplify the configuration options.
* Introduced the `StepSummary_Mode` input to control which tests to show in the GitHub step summary, replacing the `StepSummary_ShowTests` input.
* Changed the default value of `StepSummary_ShowTestOverview` to `false` to align with the new configuration approach.

### Pester Module Update:

* Updated the Pester module usage from version 3 to version 4 to ensure compatibility with the latest features and improvements.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [x] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
